### PR TITLE
Debian Support

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -32,3 +32,4 @@ Notes
 
 * The values for ``local-zone`` directive need to be specified as a list and
   surrounded by single quotes.
+* For Debian, the packaged default config includes, "/etc/unbound/unbound.conf.d". It is suggested to set the "unbound:config" pillar. See ``unbound/pillar.example``.

--- a/pillar.example
+++ b/pillar.example
@@ -1,4 +1,8 @@
 unbound:
+  # This needs to be set to True or False.
+  anti_ad: False
+  # For Debian, the default packaged config includes, "/etc/unbound/unbound.conf.d". It is suggested to set a custom config here.
+  config: /etc/unbound/unbound.conf.d/custom-unbound.conf
   lookup:
     server:
       statistics-interval: 300

--- a/unbound/map.jinja
+++ b/unbound/map.jinja
@@ -6,6 +6,13 @@ Setup variable using grains['os_family'] based logic, only add key:values here
 that differ from whats in defaults.yaml
 ##}
 {% set os_map = salt['grains.filter_by']({
+  'Debian': {
+    'service': 'unbound',
+    'package': 'unbound',
+    'config': '/etc/unbound/unbound.conf',
+    'config_dir': '/etc/unbound/unbound.conf.d',
+    'wheel_group': 'root',
+  },
   'FreeBSD': {
     'service': 'unbound',
     'package': 'unbound',


### PR DESCRIPTION
Enable support for Debian in unbound/map.jinja. Update README and pillar.example to reflect changes. Specify that anti_ad needs to be set in pillar.example.